### PR TITLE
NewDocker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:17-jdk-slim AS build
+VOLUME /tmp
+COPY ./src /app/src
+COPY ./pom.xml /app
+WORKDIR /app
+RUN ./mvnw clean package -DskipTests
+
+FROM openjdk:17-jdk-slim
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,23 @@
-FROM openjdk:17-jdk-slim AS build
-VOLUME /tmp
-COPY ./src /app/src
-COPY ./pom.xml /app
-WORKDIR /app
-RUN ./mvnw clean package -DskipTests
+FROM openjdk:21-jdk-slim AS build
 
-FROM openjdk:17-jdk-slim
-COPY --from=build /app/target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+WORKDIR /app
+
+# Copy Gradle wrapper and build files
+COPY gradlew .
+RUN chmod +x gradlew
+COPY gradle gradle
+COPY settings.gradle .
+COPY build.gradle .
+COPY application application
+COPY domain domain
+COPY infrastructure infrastructure
+COPY spring spring
+
+# Build the Spring Boot jar from the 'spring' module
+RUN ./gradlew :spring:bootJar --no-daemon
+
+FROM openjdk:21-jdk-slim
+WORKDIR /app
+COPY --from=build /app/spring/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/backend/gradlew
+++ b/backend/gradlew
@@ -114,7 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -213,7 +213,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        org.gradle.wrapper.GradleWrapperMain \
+        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/backend/gradlew.bat
+++ b/backend/gradlew.bat
@@ -70,11 +70,11 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,24 @@ services:
     networks:
       - openschool-network
 
+# OpenSchool Backend Service docker-compose requirements
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: openschool-backend
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${DB_NAME}
+      SPRING_DATASOURCE_USERNAME: ${DB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+    networks:
+      - openschool-network
+
 volumes:
   postgres_data:
 


### PR DESCRIPTION
This PR adds and configures the Gradle Wrapper for the OpenSchool backend project to enable reliable and reproducible builds, especially in Dockerized and CI environments.

Key Changes
Added Gradle Wrapper files:

gradlew and gradlew.bat scripts for Unix and Windows environments.
gradle/wrapper/gradle-wrapper.jar and gradle/wrapper/gradle-wrapper.properties for consistent Gradle version management.
Updated Dockerfile:

Ensures the Docker build uses the Gradle Wrapper to build the Spring Boot application JAR from the spring module.
Fixes build issues related to missing Gradle Wrapper files.
Verified multi-module Gradle build:

The Dockerfile now copies all necessary modules and build files.
The backend service can be built and run using Docker Compose without requiring a local Gradle installation.
Motivation
Simplifies onboarding for new contributors.
Ensures consistent build environments across local development, CI, and production.
Resolves previous Docker build failures due to missing Gradle Wrapper files.